### PR TITLE
Remove HTTP amazon test

### DIFF
--- a/src/leaphttp/testing/NetworkServicesContextTest.cpp
+++ b/src/leaphttp/testing/NetworkServicesContextTest.cpp
@@ -98,7 +98,6 @@ TEST_F(NetworkServicesContextTest, VerifyHttpGetTransfers)
 {
   const char* sites[] = {
     "http://www.abebooks.com/",
-    "http://www.amazon.com/",
     "http://www.cnn.com/",
     "http://www.msn.com/",
     "http://www.walgreens.com/"
@@ -241,7 +240,6 @@ TEST_F(NetworkServicesContextTest, VerifyHttpSimultaneousTransfers)
 {
   const char* sites[] = {
     "http://www.abebooks.com/",
-    "http://www.amazon.com/",
     "http://www.cnn.com/",
     "http://www.msn.com/",
     "http://www.walgreens.com/"


### PR DESCRIPTION
As of this morning, www.amazon.com switched it to error code 301 (permanently moved) pointing to https. We need to remove this step from our tests.
- [ ] Unit tests pass according to Jenkins logs
