### PR TITLE
Fix README title

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-NetworkServices
+LeapHTTP
 ===
 
 The library used by Leap Motion to perform certain HTTP operations


### PR DESCRIPTION
This was a bit too visible on the github page. The heading should say LeapHTTP