### PR TITLE
Allow POST content to be moved

### DIFF
--- a/src/leaphttp/HttpTransferPostString.h
+++ b/src/leaphttp/HttpTransferPostString.h
@@ -24,6 +24,23 @@ public:
     }
     request.setMethod(HttpRequest::HTTP_POST);
   }
+  HttpTransferPostString(
+    std::string userAgent,
+    const Url& url,
+    std::string&& content,
+    const std::map<std::string, std::string>& headers = {}
+  ) :
+    HttpTransferBase{ {std::move(userAgent), url} },
+    m_content(std::move(content))
+  {
+    HttpRequest& request = this->request();
+    request.setUrl(url);
+    request.setContentLength(content.size());
+    for (const auto& entry : headers) {
+      request.setHeader(entry.first, entry.second);
+    }
+    request.setMethod(HttpRequest::HTTP_POST);
+  }
   virtual ~HttpTransferPostString() = default;
 
   size_t onWrite(char* buffer, size_t bufferSize) override {


### PR DESCRIPTION
Provide interface to allow moving content instead of copying when attempting HTTP POST transfers.