### PR TITLE
Fix http integration tests

### DIFF
--- a/src/leaphttp/testing/NetworkServicesContextTest.cpp
+++ b/src/leaphttp/testing/NetworkServicesContextTest.cpp
@@ -139,7 +139,6 @@ private:
 TEST_F(NetworkServicesContextTest, VerifyHttpGetTransfers)
 {
   const char* sites[] = {
-    "http://www.abebooks.com/",
     "http://www.cnn.com/",
     "http://www.msn.com/"
   };
@@ -287,7 +286,6 @@ TEST_F(NetworkServicesContextTest, VerifyHttpsGetFailure)
 TEST_F(NetworkServicesContextTest, VerifyHttpSimultaneousTransfers)
 {
   const char* sites[] = {
-    "http://www.abebooks.com/",
     "http://www.cnn.com/",
     "http://www.msn.com/"
   };


### PR DESCRIPTION
Tests aren't passing upon investigation of #12. Note that with Travis, due to curl/openssl dependencies we test building but not actual running of `LeapHTTPTest` so I had to verify manually.

Looks like abebooks.com no longer supports insecure http, so remove it from the test sites. At some point down the road we may have to remove CNN and MSN as well.