### PR TITLE
Tighten dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ matrix:
     env:
     - _CC: gcc-4.8
     - _CXX: g++-4.8
-    - CMAKE_URL=http://cmake.org/files/v3.4/cmake-3.8.2-Linux-x86_64.tar.gz
+    - CMAKE_URL=http://cmake.org/files/v3.8/cmake-3.8.2-Linux-x86_64.tar.gz
     - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.4/autowiring-1.0.4-Linux-amd64.tar.gz
     - CMAKE_DIRNAME=cmake-3.8.2-Linux-x86_64
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
     env:
     - _CC: gcc-4.8
     - _CXX: g++-4.8
-    - CMAKE_URL=http://cmake.org/files/v3.4/cmake-3.4.0-Linux-x86_64.tar.gz
+    - CMAKE_URL=http://cmake.org/files/v3.4/cmake-3.8.2-Linux-x86_64.tar.gz
     - AUTOWIRING_URL=https://github.com/leapmotion/autowiring/releases/download/v1.0.4/autowiring-1.0.4-Linux-amd64.tar.gz
-    - CMAKE_DIRNAME=cmake-3.4.0-Linux-x86_64
+    - CMAKE_DIRNAME=cmake-3.8.2-Linux-x86_64
     addons:
       apt:
         sources:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.8)
 include(version.cmake)
 include("standard/Standard.cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 find_package(OpenSSL REQUIRED)
 
 # Standard dependencies:
-find_package(autowiring 1.0.4 REQUIRED)
+find_package(autowiring 1.0.4 EXACT REQUIRED)
 find_package(ZLIB 1.2.0 REQUIRED)
 find_package(CURL 7.35.0 REQUIRED)
 


### PR DESCRIPTION
Noticing that we had holes like missing the `EXACT` keyword in other repositories, reduce our necessary test matrix by pruning.

However, we're still defaulting to gcc 4.8 rather than 5.4 as that's what the autowiring Release binaries are built on.

- [x] Passes in Travis