### PR TITLE
Bump version to v0.1.3

### DIFF
--- a/version.cmake
+++ b/version.cmake
@@ -1,1 +1,1 @@
-set(LeapHTTP_VERSION 0.1.2)
+set(LeapHTTP_VERSION 0.1.3)


### PR DESCRIPTION
We'll be doing a minor release of LeapHTTP. This is primarily to get in sync with bugfixes from Autowiring, but it also makes for a good time to resolve build issues where SSL wasn't working on some systems.