### PR TITLE
Fix broken HTTP tests

### DIFF
--- a/src/leaphttp/testing/NetworkServicesContextTest.cpp
+++ b/src/leaphttp/testing/NetworkServicesContextTest.cpp
@@ -139,7 +139,6 @@ private:
 TEST_F(NetworkServicesContextTest, VerifyHttpGetTransfers)
 {
   const char* sites[] = {
-    "http://www.cnn.com/",
     "http://www.msn.com/"
   };
   const int numSites = sizeof(sites)/sizeof(sites[0]);
@@ -286,7 +285,6 @@ TEST_F(NetworkServicesContextTest, VerifyHttpsGetFailure)
 TEST_F(NetworkServicesContextTest, VerifyHttpSimultaneousTransfers)
 {
   const char* sites[] = {
-    "http://www.cnn.com/",
     "http://www.msn.com/"
   };
 


### PR DESCRIPTION
www.cnn.com no longer supports insecure HTTP, so remove it from the test list.

At this rate our site test list may end up empty, but this isn't a big deal as we tend to have more regressions in the https functionality and can focus on protecting that.